### PR TITLE
When storing ContentType in 'storeWordFromOtherLine', in case of 'mul…

### DIFF
--- a/resources/cgi/python_cgi_GET.py
+++ b/resources/cgi/python_cgi_GET.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os   # TO ACCESS execve ENV variables
+import time
 import sys	# to read from std input
 
 import cgi, cgitb
@@ -10,8 +11,8 @@ import cgi, cgitb
 print ("<br><br><h3>THIS IS PYTHON SCRIPT:</h3>")
 
 
-
-exit()
+time.sleep(2)
+# exit()
 
 
 # for l in sys.stdin:

--- a/resources/cgi/python_cgi_POST.py
+++ b/resources/cgi/python_cgi_POST.py
@@ -20,7 +20,7 @@ sys.stderr.write('START PYTHON SCRIPT ( via stderr)\n')
 
 # WITHOUT SLEEP, NOTHING COMES YET TO THE FieldStoraeg() 
 # AND IT THEREFORE GIVES PYTHON ERROR: [Errno 35] Resource temporarily unavailable
-# time.sleep(2)
+time.sleep(2)
 
 
 class StdinStream(object):

--- a/srcs/RequestParser.cpp
+++ b/srcs/RequestParser.cpp
@@ -199,8 +199,12 @@ int Request::storeWordsFromOtherLine(std::string otherLine) {
 				_data.setRequestContentLength(*iter);
 			}
 			else if ((*iter).substr(0, 13) == "Content-Type:") {
-				iter++;		//				multipart;		boundary ---									
-				_data.setRequestContentType((*iter) + " " + *(++iter));
+				iter++;		
+				if ((*iter).find("multipart") == std::string::npos)	
+					_data.setRequestContentType(*iter);
+				else			//				multipart;		boundary ---
+					_data.setRequestContentType((*iter) + " " + *(++iter));
+				
 				//std::cout << RED " .... .... header line *Iter: [" << *iter << "]\n" RES;
 				//std::cout << RED " .... .... header line Content-Type: [" << _data.getRequestContentType() << "]\n" RES;
 

--- a/srcs/RequestParserURLpath.cpp
+++ b/srcs/RequestParserURLpath.cpp
@@ -104,7 +104,7 @@ void Request::callCGI(struct kevent event) {
 	// BY HERE, THE HUGE BODY IS STORED OK
 
 	// Make a char** array and copy all content of the above vector
-	std::cout << GRN " ...... TEMP SIZE:  " << temp.size() << " \n" << RES "\n";
+	//std::cout << GRN " ...... TEMP SIZE:  " << temp.size() << " \n" << RES "\n";
 
 	char **env = new char*[temp.size() + 1];
 
@@ -118,7 +118,7 @@ void Request::callCGI(struct kevent event) {
 	// BY HERE, THE HUGE BODY IS STORED OK
 
 	// Just for printing
-	std::cout << GRN "STORED ENV:\n" << RES "\n";
+	std::cout << GRN "STORED ENV:\n" RES;
 	for (i = 0; env[i]; i++) {
 	  std::cout << "    " << i+1 << " " << env[i] << std::endl;
 	}

--- a/srcs/ResponseData.cpp
+++ b/srcs/ResponseData.cpp
@@ -133,9 +133,9 @@ void ResponseData::setResponse(struct kevent& event) {
 
 
 			_responseBody = streamFile(_responsePath);
-			std::cout << YEL "                              getHttpStatus(): [" << storage->getHttpStatus() << "]\n" RES;// todo JOYCE map enums to strings
-			std::cout << YEL "                           response path: [" << _responsePath << "]\n" RES;
-			std::cout << YEL "    content type should now be text/html: [" << storage->getRequestData().getResponseContentType() << RES "]\n";
+			std::cout << YEL "   getHttpStatus(): [" << storage->getHttpStatus() << "]\n" RES;// todo JOYCE map enums to strings
+			std::cout << YEL "   response path:   [" << _responsePath << "]\n" RES;
+			std::cout << YEL "   content type:    [" << storage->getRequestData().getResponseContentType() << RES "]\n";
 		//}
 	}
 	// IF NOT A FOLDER
@@ -168,7 +168,7 @@ void ResponseData::setResponse(struct kevent& event) {
 
 	// std::cout << YEL "complete response header: [" << _responseHeader << "]\n";
 	_fullResponse += _responseHeader + _responseBody;
-	std::cout << YEL "\n_fullResponse:\n[\n" RES << _fullResponse << YEL "]\n" RES;
+	//std::cout << YEL "\n_fullResponse:\n[\n" RES << _fullResponse << YEL "]\n" RES;
 
 }
 
@@ -255,8 +255,9 @@ std::string ResponseData::setImage(std::string imagePath) {
 	headerBlock.append("accept-ranges: bytes\r\n");
 	std::string contentLen = "Content-Length: ";
 	std::string temp = std::to_string(content.size());
-	headerBlock.append(contentLen);
+	std::cout << "from setImage: content-length: " << temp << "\n";
 	contentLen.append(temp);
+	headerBlock.append(contentLen);
 	headerBlock.append("\r\n\r\n");
 
 	headerBlock.append(content);

--- a/srcs/WebServer.cpp
+++ b/srcs/WebServer.cpp
@@ -259,6 +259,7 @@ void WebServer::sendResponse(struct kevent& event)
 
 		std::string content = storage->getResponseData().getFullResponse();
 		std::cout << GRN << "Full Response size: " RES << content.size() << RES << std::endl;
+		//std::cout << GRN << "Full Response Content:  Temp disabled by Jaka\n" RES << std::endl;
 		std::cout << GRN << "Full Response Content:\n[\n" RES << content<< GRN "]\n" RES << std::endl;
 		unsigned long myRet = 0;
 


### PR DESCRIPTION
…tipart' content, it needs to distingush from other types, because multipart has 2 keys. - In child process the python scripts need to have a little sleep, otherwise the connection closes prematurely